### PR TITLE
Hotfixes:

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
@@ -14,6 +14,7 @@ abstract class BaseFormItem implements Renderable, FormItemInterface
 	protected $field_size;
 	protected $help_text;
 	protected $validationRules = [];
+	protected $custom = false;
 
 	public function initialize()
 	{
@@ -72,6 +73,16 @@ abstract class BaseFormItem implements Renderable, FormItemInterface
 			return $this->help_text;
 		}
 		$this->help_text = $help_text;
+		return $this;
+	}
+
+	public function custom($custom = null)
+	{
+		if (is_null($custom))
+		{
+			return $this->custom;
+		}
+		$this->custom = $custom;
 		return $this;
 	}
 

--- a/src/SleepingOwl/Admin/FormItems/Columns.php
+++ b/src/SleepingOwl/Admin/FormItems/Columns.php
@@ -57,6 +57,8 @@ class Columns extends BaseFormItem
 		{
 			$item->initialize();
 		});
+
+		$this->custom(true);
 	}
 
 	public function setInstance($instance)

--- a/src/SleepingOwl/Admin/FormItems/Custom.php
+++ b/src/SleepingOwl/Admin/FormItems/Custom.php
@@ -6,6 +6,12 @@ class Custom extends BaseFormItem
 	protected $display;
 	protected $callback;
 
+	public function initialize()
+	{
+		parent::initialize();
+		$this->custom(true);
+	}
+
 	public function display($display = null)
 	{
 		if (is_null($display))

--- a/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
@@ -99,7 +99,7 @@ abstract class NamedFormItem extends BaseFormItem
 
 	public function getParams()
 	{
-		
+
 		return parent::getParams() + [
 			'name'      => $this->name(),
 			'label'     => $this->label(),
@@ -152,7 +152,7 @@ abstract class NamedFormItem extends BaseFormItem
             return $value->$attribute;
         }
 
-        if (!is_null($instance) && !is_null($value = $instance->getAttribute($attribute))) {
+        if (!is_null($instance) && !$this->lang() && !is_null($value = $instance->getAttribute($attribute))) {
             return $value;
         }
 
@@ -176,7 +176,7 @@ abstract class NamedFormItem extends BaseFormItem
 			} else {
 				$this->instance()->$attribute = $value;
 			}
-		}	
+		}
 	}
 
 	public function required()
@@ -206,7 +206,7 @@ abstract class NamedFormItem extends BaseFormItem
 			}
 		});
 		return [
-			$this->name() => $rules
+			$this->path() => $rules
 		];
 	}
 

--- a/src/SleepingOwl/Admin/FormItems/Select.php
+++ b/src/SleepingOwl/Admin/FormItems/Select.php
@@ -8,6 +8,7 @@ class Select extends NamedFormItem
 
 	protected $view = 'select';
 	protected $model;
+	protected $with;
 	protected $display = 'title';
 	protected $options = [];
 	protected $nullable = false;
@@ -22,6 +23,16 @@ class Select extends NamedFormItem
 			return $this->model;
 		}
 		$this->model = $model;
+		return $this;
+	}
+
+	public function with($with = null)
+	{
+		if (is_null($with))
+		{
+			return $this->with;
+		}
+		$this->with = $with;
 		return $this;
 	}
 
@@ -71,7 +82,13 @@ class Select extends NamedFormItem
 		$display = explode('|', $this->display());
 
 		$key = $repository->model()->getKeyName();
-		$model = $repository->query()->get(array_add($display, 'id', 'id'));
+
+		$model = $repository->query();
+		if ( !is_null($this->with())) {
+			$model = $model->with($this->with());
+		}
+		$model = $model->get();
+
 		$options = [];
 		$value = "";
 

--- a/src/SleepingOwl/Admin/FormItems/TinyMCE.php
+++ b/src/SleepingOwl/Admin/FormItems/TinyMCE.php
@@ -48,7 +48,7 @@ class TinyMCE extends NamedFormItem
     public function getParams()
     {
         return parent::getParams() + [
-          'config' => json_encode($this->mce_config()),
+          'config' => str_replace('"elFinderBrowser"', 'elFinderBrowser', json_encode($this->mce_config() )),
           'selector' => $this->mce_selector(),
         ];
     }

--- a/src/SleepingOwl/Admin/Http/Controllers/AdminController.php
+++ b/src/SleepingOwl/Admin/Http/Controllers/AdminController.php
@@ -129,7 +129,7 @@ class AdminController extends Controller
 			'lang'   => $lang,
 			'ckeditor_cfg' => config('admin.ckeditor')
 		);
-		
+
 		$content = 'window.admin = '.json_encode($data) . ';';
 
 		$response = new Response($content, 200, [
@@ -153,4 +153,4 @@ class AdminController extends Controller
 		abort(404);
 	}
 
-} 
+}

--- a/src/SleepingOwl/Admin/Http/Middleware/AdminAuthenticate.php
+++ b/src/SleepingOwl/Admin/Http/Middleware/AdminAuthenticate.php
@@ -35,10 +35,13 @@ class AdminAuthenticate
 		if( count( $request->route()->parameters() ) == 0 ) {
 
 			//Dashboard or some custom page
-			if( $request->route()->getName() == "admin.dashboard" || starts_with($request->route()->getName(), "admin.upload.")) {
+			if( $request->route()->getName() == "admin.dashboard" || starts_with($request->route()->getName(), "admin.upload.") || starts_with($request->route()->getName(), "elfinder.")) {
 				if (\Sentinel::hasAnyAccess(['superadmin', 'controlpanel']))
 				{
 					return $next($request);
+				}
+				else {
+					return redirect()->guest(route('admin.login'));
 				}
 			}
 

--- a/src/SleepingOwl/Admin/Templates/TemplateDefault.php
+++ b/src/SleepingOwl/Admin/Templates/TemplateDefault.php
@@ -34,7 +34,7 @@ class TemplateDefault implements TemplateInterface
 		{
 			return $currentView;
 		}
-		return 'admin::default.' . $view;
+		abort(404);
 	}
 
 }

--- a/src/views/default/formitem/errors.blade.php
+++ b/src/views/default/formitem/errors.blade.php
@@ -1,3 +1,9 @@
-@foreach ($errors->get($name) as $error)
+<?php
+	$prefix = "";
+	if (isset($lang)) {
+		$prefix = $lang . '_';
+	}
+?>
+@foreach ($errors->get($prefix . $name) as $error)
 	<p class="help-block">{{ $error }}</p>
 @endforeach

--- a/src/views/default/formitem/text.blade.php
+++ b/src/views/default/formitem/text.blade.php
@@ -1,4 +1,4 @@
-<div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
+<div class="form-group {{ $errors->has($name) || $errors->has($lang . '_' . $name) ? 'has-error' : '' }}">
 	<label for="@if($lang){{ $lang }}.@endif{{ $name }}" @if($label_size) class="{{ $label_size }}" @endif >
 		{{ $label }}
 		@if($required_field)
@@ -8,7 +8,7 @@
     @if($field_size)
     	<div class="{{ $field_size }}">
     @endif
-	<input class="form-control" name="@if($lang){{ $lang }}.@endif{{ $name }}" type="text" id="@if($lang){{ $lang }}.@endif{{ $name }}" value="{{ $value }}">
+	<input class="form-control" @if($readonly) readonly @endif name="@if($lang){{ $lang }}{{'_'}}@endif{{$name}}" type="text" id="@if($lang){{ $lang }}{{'_'}}@endif{{$name}}" value="{{ $value }}">
 	@include(AdminTemplate::view('formitem.help'))
 	@include(AdminTemplate::view('formitem.errors'))
  	@if($field_size)

--- a/src/views/default/formitem/textarea.blade.php
+++ b/src/views/default/formitem/textarea.blade.php
@@ -1,5 +1,5 @@
-<div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
-	<label for="{{ $name }}" @if($label_size) class="{{ $label_size }}" @endif >
+<div class="form-group {{ $errors->has($name) || $errors->has($lang . '_' . $name) ? 'has-error' : '' }}">
+	<label for="@if($lang){{ $lang }}.@endif{{ $name }}" @if($label_size) class="{{ $label_size }}" @endif >
 		{{ $label }}
 		@if($required_field)
 			@include(AdminTemplate::view('formitem.required'))
@@ -8,7 +8,7 @@
     @if($field_size)
     	<div class="{{ $field_size }}">
     @endif
-	<textarea class="form-control" cols="50" rows="10" name="{{ $name }}">{!! $value !!}</textarea>
+	<textarea class="form-control" cols="50" rows="{{ $rows }}" name="@if($lang){{ $lang }}{{'_'}}@endif{{ $name }}">{!! $value !!}</textarea>
 	@include(AdminTemplate::view('formitem.help'))
 	@include(AdminTemplate::view('formitem.errors'))
 	@if($field_size)

--- a/src/views/default/formitem/tinymce.blade.php
+++ b/src/views/default/formitem/tinymce.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
-    <label for="{{ $name }}" @if($label_size) class="{{ $label_size }}" @endif >
+    <label for="@if($lang){{ $lang }}.@endif{{ $name }}" @if($label_size) class="{{ $label_size }}" @endif >
         {{ $label }}
         @if($required_field)
             @include(AdminTemplate::view('formitem.required'))
@@ -8,7 +8,7 @@
     @if($field_size)
         <div class="{{ $field_size }}">
             @endif
-            <textarea id="{{ $selector }}" name="{{ $name }}">{!! $value !!}</textarea>
+            <textarea id="@if($lang){{ $lang }}{{ '_' }}@endif{{ 'tinymce' }}" name="@if($lang){{ $lang }}.@endif{{ $name }}">{!! $value !!}</textarea>
             @include(AdminTemplate::view('formitem.errors'))
             @if($field_size)
         </div>


### PR DESCRIPTION
- Validation of multilang form fields is working correctly now. For this a new feature is build in, so for the validation message the label of field is usd
- Dynamic options for TinyMCE field supports elfinder.
- Admin Middleware: add ElFinder Support and fix #47
- When admin view not found not application drops a not found error.
- add missing support for row feature within textarea.

Features:

- Add relationsship support within select model function, e.g. ->model()->with()