### PR TITLE
disable columns from the global search in datatables

### DIFF
--- a/public/default/scripts/datatables/init.js
+++ b/public/default/scripts/datatables/init.js
@@ -23,6 +23,7 @@ $(function ()
    			
 		};
 		params = $.extend(params, $this.data('attributes'));
+		params = $.extend(params, $this.data('soa-excludesearch'));
 
 		var url;
 		if (url = $this.data('url'))

--- a/src/SleepingOwl/Admin/Display/DisplayDatatables.php
+++ b/src/SleepingOwl/Admin/Display/DisplayDatatables.php
@@ -21,10 +21,11 @@ class DisplayDatatables extends DisplayTable
 			'asc'
 		]
 	];
-	protected $columnFilters 	= [];
-	protected $attributes 		= [];
-
-	protected $exportButtons	= [];
+	protected $columnFilters 		= [];
+	protected $attributes 			= [];
+	protected $searchExcludeColumns	= [];
+	protected $exportButtons		= [];
+	protected $disableSearch 		= [];
 
 	/**
 	 * Initialize display
@@ -63,6 +64,28 @@ class DisplayDatatables extends DisplayTable
 			return $this->columnFilters;
 		}
 		$this->columnFilters = $columnFilters;
+		return $this;
+	}
+
+	public function excludeSearch($searchExcludeColumns = null)
+	{
+		if (is_null($searchExcludeColumns))
+		{
+			return $this->searchExcludeColumns;
+		}
+
+
+		$excludeColumns = [];		
+
+		foreach($searchExcludeColumns as $key => $value) {
+			
+			$excludeColumns['columnDefs'][] = [
+				'searchable' 	=> $value[1],
+				'targets'		=> $value[0]
+			];
+		}
+
+		$this->searchExcludeColumns = $excludeColumns;
 		return $this;
 	}
 
@@ -114,11 +137,12 @@ class DisplayDatatables extends DisplayTable
 	 */
 	protected function getParams()
 	{
-		$params = parent::getParams();
-		$params['order'] = $this->order();
-		$params['columnFilters'] = $this->columnFilters();
-		$params['attributes'] = $this->attributes();
+		$params 					= parent::getParams();
+		$params['order'] 			= $this->order();
+		$params['columnFilters'] 	= $this->columnFilters();
+		$params['attributes'] 		= $this->attributes();
 		$params['exportButtons']	= $this->exportButtons();
+		$params['excludeSearch']	= $this->excludeSearch();
 		return $params;
 	}
 

--- a/src/SleepingOwl/Admin/Display/DisplayDatatablesAsync.php
+++ b/src/SleepingOwl/Admin/Display/DisplayDatatablesAsync.php
@@ -160,18 +160,25 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
 			return;
 		}
 
-		$query->where(function ($query) use ($search)
+		$dtColumns = Input::get('columns', []);
+
+		$query->where(function ($query) use ($search, $dtColumns)
 		{
+
 			$columns = $this->columns();
-			foreach ($columns as $column)
+			foreach ($columns as $key => $column)
 			{
 				if ($column instanceof String)
 				{
-					$name = $column->name();
+					$searchable = array_get($dtColumns[$key], 'searchable');	
+					$name 		= $column->name();
+					
 					if ($this->repository->hasColumn($name))
 					{
-						$query->orWhere($name, 'like', '%' . $search . '%');
-					}
+						if( $searchable == "true" ) {
+							$query->orWhere($name, 'like', '%' . $search . '%');
+						}
+					}	
 				}
 			}
 		});
@@ -184,10 +191,10 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
 		{
 			$search = array_get($queryColumn, 'search.value');
 			$fullSearch = array_get($queryColumn, 'search');
-
+			$searchable = array_get($queryColumn, 'searchable');
 			$column = array_get($this->columns(), $index);
 			$columnFilter = array_get($this->columnFilters(), $index);
-			if ( ! is_null($columnFilter))
+			if ( ! is_null($columnFilter) && $searchable == "true" )
 			{
 				$columnFilter->apply($this->repository, $column, $query, $search, $fullSearch);
 			}

--- a/src/views/default/display/datatables.blade.php
+++ b/src/views/default/display/datatables.blade.php
@@ -17,7 +17,7 @@
 
     <div class="box-body">
 
-		<table class="table table-striped datatables" data-order="{{ json_encode($order) }}" data-attributes="{{ json_encode($attributes, JSON_FORCE_OBJECT) }}" @if( count($exportButtons) > 0) data-soa-buttons="{{ json_encode($exportButtons) }}" @endif>
+		<table class="table table-striped datatables" data-soa-excludesearch="{{ json_encode($excludeSearch) }}" data-order="{{ json_encode($order) }}" data-attributes="{{ json_encode($attributes, JSON_FORCE_OBJECT) }}" @if( count($exportButtons) > 0) data-soa-buttons="{{ json_encode($exportButtons) }}" @endif>
 		<thead>
 			<tr>
 				@foreach ($columns as $column)

--- a/src/views/default/display/datatablesAsync.blade.php
+++ b/src/views/default/display/datatablesAsync.blade.php
@@ -17,7 +17,7 @@
 
     <div class="box-body">
 
-		<table class="table table-striped datatables" data-url="{{ $url }}" data-order="{{ json_encode($order) }}" data-attributes="{{ json_encode($attributes, JSON_FORCE_OBJECT) }}" @if( count($exportButtons) > 0) data-soa-buttons="{{ json_encode($exportButtons) }}" @endif>
+		<table class="table table-striped datatables" data-url="{{ $url }}" data-soa-excludesearch="{{ json_encode($excludeSearch) }}" data-order="{{ json_encode($order) }}" data-attributes="{{ json_encode($attributes, JSON_FORCE_OBJECT) }}" @if( count($exportButtons) > 0) data-soa-buttons="{{ json_encode($exportButtons) }}" @endif>
 		<thead>
 			<tr>
 				@foreach ($columns as $column)


### PR DESCRIPTION
#63 - added functionality to disable columns from the global search in data tables (sync/async)

Example:
	$display = AdminDisplay::datatables();
	$display->excludeSearch([
	 	[0, false]
	]);