### PR TITLE
TreeDisplay, Login Form Translation and String Column

### DIFF
--- a/src/SleepingOwl/Admin/Display/DisplayTree.php
+++ b/src/SleepingOwl/Admin/Display/DisplayTree.php
@@ -26,6 +26,12 @@ class DisplayTree implements Renderable, DisplayInterface, WithRoutesInterface
 	protected $apply;
 	protected $scopes;
 
+	public function __construct($class=null) {
+		if ( !is_null ( $class ) ) {
+			$this->setClass($class);
+		}
+	}
+
 	public function setClass($class)
 	{
 		if (is_null($this->class))

--- a/src/SleepingOwl/Admin/Http/Controllers/AuthController.php
+++ b/src/SleepingOwl/Admin/Http/Controllers/AuthController.php
@@ -57,10 +57,10 @@ class AuthController extends Controller
 		
 
 		$message = new MessageBag([
-			'email' => trans('sentinel::lang.auth.wrong-email'),
-			'password' => trans('sentinel::lang.auth.wrong-password')
+			'email' => trans('admin::lang.auth.wrong-email'),
+			'password' => trans('admin::lang.auth.wrong-password')
 		]);
-		
+
 		return \Redirect::back()->withInput()->withErrors($message);
 	}
 

--- a/src/views/default/column/string.blade.php
+++ b/src/views/default/column/string.blade.php
@@ -1,1 +1,1 @@
-<td>{{ $value }} {!! $append !!}</td>
+<td>{!! $value !!} {!! $append !!}</td>


### PR DESCRIPTION
* Missing "__construct()" within TreeDisplay
* Add MIssing Translation for Login Form Error
* Change `{{ }}` to `{!! !!}` within string column.