### PR TITLE
Bugfixes: TinyMCE & ELFinder / Error Messages

### DIFF
--- a/src/SleepingOwl/Admin/Form/FormDefault.php
+++ b/src/SleepingOwl/Admin/Form/FormDefault.php
@@ -6,6 +6,7 @@ use Illuminate\View\View;
 use Input;
 use SleepingOwl\Admin\Admin;
 use SleepingOwl\Admin\AssetManager\AssetManager;
+use SleepingOwl\Admin\FormItems\Columns;
 use SleepingOwl\Admin\Interfaces\DisplayInterface;
 use SleepingOwl\Admin\Interfaces\FormInterface;
 use SleepingOwl\Admin\Interfaces\FormItemInterface;
@@ -357,7 +358,21 @@ class FormDefault implements Renderable, DisplayInterface, FormInterface
 			$items = $this->items();
 			array_walk_recursive($items, function ($item) use (&$names) {
 				if ($item instanceof FormItemInterface && !$item->custom() ) {
-					$names = array_add($names, $item->path(), $item->label());
+					if ( $item instanceof Columns ) {
+
+						foreach ($item->columns() as $columnItems)
+						{
+							foreach ($columnItems as $columnItem)
+							{
+								if ($columnItem instanceof FormItemInterface)
+								{
+									$names = array_add($names, $columnItem->path(), $columnItem->label());
+								}
+							}
+						}
+					} else {
+						$names = array_add($names, $item->path(), $item->label());
+					}
 				}
 			});
 

--- a/src/SleepingOwl/Admin/FormItems/Columns.php
+++ b/src/SleepingOwl/Admin/FormItems/Columns.php
@@ -60,8 +60,6 @@ class Columns extends BaseFormItem
 			$item->setFieldSize($this->field_size);
 			$item->setLabelSize($this->label_size);
 		});
-
-		$this->custom(true);
 	}
 
 	public function setInstance($instance)

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -111,6 +111,14 @@ return [
 			"path"	=> "elfinder/ckeditor" 
 		]
 	],
+	
+	/**
+	 * If you are using tinymce as WYSIWYG editor you can enable here the elfinder javascript to use elfinder with tinymce.
+	 */
+	
+	'tinymce' => [
+		'enable_elfinder' => false
+	],
 
 	/**
 	 * Define here your custom route with permissions, so that we can handle them
@@ -118,6 +126,6 @@ return [
 	 * When you leave permission empty, we default using the defaultPermission array in this config
 	 */
 	'custom_routes' => [
-			'admin.dashboard' => ''
+		'admin.dashboard' => ''
 	]
 ];

--- a/src/views/default/_layout/base.blade.php
+++ b/src/views/default/_layout/base.blade.php
@@ -28,7 +28,11 @@
 	      	});
 		</script>
 		@endif
-		
+
+		@if( Config::get('admin.tinymce.enable_elfinder') )
+		@include(AdminTemplate::view('_partials.elfinder'))
+		@endif
+
 	</head>
 
 	<body class="skin-{!! Config::get('admintheme.skin') !!} @if( Config::get('admintheme.sidebar_mini') )sidebar-mini @endif @if( Config::get('admintheme.boxed_layout') ) layout-boxed @endif @if( Config::get('admintheme.fixed_layout') ) fixed @endif @if( Config::get('admintheme.toggle_sidebar') ) sidebar-collapse @endif @yield('body')">

--- a/src/views/default/_partials/elfinder.blade.php
+++ b/src/views/default/_partials/elfinder.blade.php
@@ -1,0 +1,17 @@
+<script>
+    function elFinderBrowser(callback, value, meta) {
+        var request = "{{ action('\Barryvdh\Elfinder\ElfinderController@showTinyMCE4') }}";
+        tinymce.activeEditor.windowManager.open({
+            title: 'File Manager',
+            url: request,
+            width: 900,
+            height: 550,
+        }, {
+            oninsert: function (url) {
+                callback(url);
+            }
+        });
+
+        return false;
+    }
+</script>

--- a/src/views/default/formitem/errors.blade.php
+++ b/src/views/default/formitem/errors.blade.php
@@ -1,6 +1,6 @@
 <?php
 	$prefix = "";
-	if (isset($lang)) {
+	if (!empty($lang)) {
 		$prefix = $lang . '_';
 	}
 ?>


### PR DESCRIPTION
* add javascript method for elfinder to avoid error when using TinyMCE with elfinder (config usage)
* error messages without ajax validation are shown correctly
* column form item can handle now automatically label detection for validation error messages