### PR TITLE
Fix NamedFormItem path and attribute methods

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
@@ -41,7 +41,7 @@ abstract class NamedFormItem extends BaseFormItem
 			}
 		}
 		$this->path = $path;
-		return $path;
+		return $this;
 	}
 
 	public function attribute($attribute = null)
@@ -55,7 +55,7 @@ abstract class NamedFormItem extends BaseFormItem
 			//}
 		}
 		$this->attribute = $attribute;
-		return $attribute;
+		return $this;
 	}
 
 	public function name($name = null)


### PR DESCRIPTION
I am not sure whether this is a bug or not, but I thought I would submit a Pull Request anyway. Basically all other read / write accessors in the library are fluent, but these two return their value. I have updated them to return `$this` to resolve this. 