### PR TITLE
Allow saving of relations with select

### DIFF
--- a/src/SleepingOwl/Admin/Form/FormDefault.php
+++ b/src/SleepingOwl/Admin/Form/FormDefault.php
@@ -60,6 +60,13 @@ class FormDefault implements Renderable, DisplayInterface, FormInterface
 	 */
 	protected $initialized = false;
 
+	/**
+	 * Use Eloquent's push method instead of save. 
+	 * This will enable relationship saving. 
+	 * @var boolean
+	 */
+	protected $usePush = false;
+
 	protected $horizontal = false;
 	protected $label_size = "col-sm-2";
 	protected $field_size = "col-sm-10";
@@ -166,6 +173,17 @@ class FormDefault implements Renderable, DisplayInterface, FormInterface
 			return $this->storable;
 		}
 		$this->storable = $storable;
+		return $this;
+	}
+
+	public function usePush($usePush = null) 
+	{
+		if (is_null($usePush))
+		{
+			return $this->usePush;
+		}
+
+		$this->usePush = $usePush;
 		return $this;
 	}
 
@@ -282,7 +300,15 @@ class FormDefault implements Renderable, DisplayInterface, FormInterface
 				$item->save();
 			}
 		});
-		$this->instance()->save();
+
+		if ($this->usePush) 
+		{
+			$this->instance()->push();
+		}
+		else 
+		{
+			$this->instance()->save();
+		}		
 	}
 
 	/**

--- a/src/SleepingOwl/Admin/Form/FormDefault.php
+++ b/src/SleepingOwl/Admin/Form/FormDefault.php
@@ -60,13 +60,6 @@ class FormDefault implements Renderable, DisplayInterface, FormInterface
 	 */
 	protected $initialized = false;
 
-	/**
-	 * Use Eloquent's push method instead of save. 
-	 * This will enable relationship saving. 
-	 * @var boolean
-	 */
-	protected $usePush = false;
-
 	protected $horizontal = false;
 	protected $label_size = "col-sm-2";
 	protected $field_size = "col-sm-10";
@@ -173,17 +166,6 @@ class FormDefault implements Renderable, DisplayInterface, FormInterface
 			return $this->storable;
 		}
 		$this->storable = $storable;
-		return $this;
-	}
-
-	public function usePush($usePush = null) 
-	{
-		if (is_null($usePush))
-		{
-			return $this->usePush;
-		}
-
-		$this->usePush = $usePush;
 		return $this;
 	}
 
@@ -301,14 +283,15 @@ class FormDefault implements Renderable, DisplayInterface, FormInterface
 			}
 		});
 
-		if ($this->usePush) 
+		$this->instance()->save();
+
+		array_walk_recursive($items, function ($item)
 		{
-			$this->instance()->push();
-		}
-		else 
-		{
-			$this->instance()->save();
-		}		
+			if ($item instanceof FormItemInterface)
+			{
+				$item->saved();
+			}
+		});	
 	}
 
 	/**

--- a/src/SleepingOwl/Admin/FormItems/Columns.php
+++ b/src/SleepingOwl/Admin/FormItems/Columns.php
@@ -50,6 +50,15 @@ class Columns extends BaseFormItem
 		});
 	}
 
+	public function saved()
+	{
+		parent::saved();
+		$this->all(function ($item)
+		{
+			$item->saved();
+		});
+	}
+
 	public function initialize()
 	{
 		parent::initialize();


### PR DESCRIPTION
I was creating a form the other day that assigned many of one model to another during creation. At the moment the this is not possible. 

In this pull request I have added an option to the DefaultForm class which switches it to use `push` instead of `save`.