### PR TITLE
Bug Fixes

### DIFF
--- a/src/SleepingOwl/Admin/AdminServiceProvider.php
+++ b/src/SleepingOwl/Admin/AdminServiceProvider.php
@@ -119,14 +119,12 @@ class AdminServiceProvider extends ServiceProvider
     		\App::setLocale(\Config::get('app.locale'));
     	}
 
+        Admin::instance();
 
 		$this->registerTemplate();
 		$this->registerProviders();
 		$this->registerAliases();
 		$this->initializeTemplate();
-
-		Admin::instance();
-
 	}
 
 	/**

--- a/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
@@ -115,6 +115,11 @@ abstract class BaseFormItem implements Renderable, FormItemInterface
 	{
 	}
 
+	public function saved()
+	{
+		
+	}
+
 	public function getParams()
 	{
 		return [


### PR DESCRIPTION
I come across an intermittent bug where the Admin instance is not initialized quick enough. This resulted in the Menu being constructed incorrectly as `MenuItem::$current` was null. 